### PR TITLE
Use speedy travis wheels from rasterio 0.26.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
+sudo: false
 language: python
 env:
   - RASTERIO_VERSION=0.26.0
+addons:
+  apt:
+    packages:
+      - libgdal1h
+      - gdal-bin
 python:
   - "2.7"
   - "3.4"
@@ -9,12 +15,10 @@ cache:
     - $HOME/.pip-cache/
     - $HOME/wheelhouse
 before_install:
-  - sudo add-apt-repository -y ppa:ubuntugis/ppa
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libgdal1h gdal-bin
   - curl -L https://github.com/mapbox/rasterio/releases/download/$RASTERIO_VERSION/rasterio-travis-wheels-$TRAVIS_PYTHON_VERSION.tar.gz > /tmp/wheelhouse.tar.gz
   - tar -xzvf /tmp/wheelhouse.tar.gz -C $HOME
 install:
+  - "pip install -U pip"
   - "pip install coveralls"
   - "pip install --use-wheel --find-links=$HOME/wheelhouse -e .[test] --cache-dir $HOME/.pip-cache"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
     - $HOME/.pip-cache/
     - $HOME/wheelhouse
 before_install:
-  - "./travis_riodeps.sh"
+  - "./.travis_riodeps.sh"
 install:
   - "pip install -U pip"
   - "pip install coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - "./.travis_riodeps.sh"
 install:
   - "pip install -U pip"
-  - "pip install coveralls"
+  - "pip install --use-wheel --find-links=$HOME/wheelhouse coveralls --cache-dir $HOME/.pip-cache"
   - "pip install --use-wheel --find-links=$HOME/wheelhouse -e .[test] --cache-dir $HOME/.pip-cache"
 script:
   - py.test --cov riomucho --cov-report term-missing

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ cache:
     - $HOME/.pip-cache/
     - $HOME/wheelhouse
 before_install:
-  - curl -L https://github.com/mapbox/rasterio/releases/download/$RASTERIO_VERSION/rasterio-travis-wheels-$TRAVIS_PYTHON_VERSION.tar.gz > /tmp/wheelhouse.tar.gz
-  - tar -xzvf /tmp/wheelhouse.tar.gz -C $HOME
+  - ./travis_riodeps.sh
 install:
   - "pip install -U pip"
   - "pip install coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
 language: python
+env:
+  - RASTERIO_VERSION=0.26.0
 python:
   - "2.7"
   - "3.4"
+cache:
+  directories:
+    - $HOME/.pip-cache/
+    - $HOME/wheelhouse
 before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ppa
   - sudo apt-get update -qq
-  - sudo apt-get install -y libgdal1h gdal-bin libgdal-dev
+  - sudo apt-get install -y libgdal1h gdal-bin
+  - curl -L https://github.com/mapbox/rasterio/releases/download/$RASTERIO_VERSION/rasterio-travis-wheels-$TRAVIS_PYTHON_VERSION.tar.gz > /tmp/wheelhouse.tar.gz
+  - tar -xzvf /tmp/wheelhouse.tar.gz -C $HOME
 install:
   - "pip install coveralls"
-  - "pip install -e .[test]"
-script: 
-  - py.test
-  - coverage run --source=riomucho -m py.test
+  - "pip install --use-wheel --find-links=$HOME/wheelhouse -e .[test] --cache-dir $HOME/.pip-cache"
+script:
+  - py.test --cov riomucho --cov-report term-missing
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
     - $HOME/.pip-cache/
     - $HOME/wheelhouse
 before_install:
-  - ./travis_riodeps.sh
+  - "./travis_riodeps.sh"
 install:
   - "pip install -U pip"
   - "pip install coveralls"

--- a/.travis_riodeps.sh
+++ b/.travis_riodeps.sh
@@ -7,7 +7,7 @@ set -e
 
 WHEELHOUSE=$HOME/wheelhouse
 
-if [[ ! -e "$WHEELHOUSE/rasterio-$RASTERIO_VERSION-cp27-none-linux_x86_64.whl" ]]; then
+if test -z $(find $WHEELHOUSE -name rasterio-$RASTERIO_VERSION-*-none-linux_x86_64.whl); then
     echo "Downloading speedy wheels..."
     curl -L https://github.com/mapbox/rasterio/releases/download/$RASTERIO_VERSION/rasterio-travis-wheels-$TRAVIS_PYTHON_VERSION.tar.gz > /tmp/wheelhouse.tar.gz
     echo "Extracting speedy wheels..."

--- a/.travis_riodeps.sh
+++ b/.travis_riodeps.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Conditionally download a wheelset satisfying Rasterio's dependencies to 
+# speed up builds.
+
+set -e
+
+WHEELHOUSE=$HOME/wheelhouse
+
+if [[ ! -e "$WHEELHOUSE/rasterio-$RASTERIO_VERSION-cp27-none-linux_x86_64.whl" ]]; then
+    echo "Downloading speedy wheels..."
+    curl -L https://github.com/mapbox/rasterio/releases/download/$RASTERIO_VERSION/rasterio-travis-wheels-$TRAVIS_PYTHON_VERSION.tar.gz > /tmp/wheelhouse.tar.gz
+    echo "Extracting speedy wheels..."
+    tar -xzvf /tmp/wheelhouse.tar.gz -C $HOME
+else
+    echo "Using existing wheelhouse."
+fi

--- a/.travis_riodeps.sh
+++ b/.travis_riodeps.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 #
-# Conditionally download a wheelset satisfying Rasterio's dependencies to 
+# Conditionally download a wheel set satisfying Rasterio's dependencies to
 # speed up builds.
+#
+# If we find the right rasterio wheel in the wheelhouse directory, we skip
+# the download. Else, we download and extract into the wheelhouse dir.
 
 set -e
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(name='rio-mucho',
           'numpy'
       ],
       extras_require={
-          'test': ['pytest'],
+          'test': ['pytest', 'pytest-cov'],
       }
       )


### PR DESCRIPTION
This means we can drop the apt requirement for GDAL's dev pkg and don't spend any time compiling Rasterio or Numpy.
