### PR TITLE
Update .travis.yml to account for rasterio wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,60 @@
-sudo: false
 language: python
+
+sudo: false
+
+cache:
+  # Apparently if you override the install command that silently disables the
+  # cache: pip support. This is less than ideal and I've opened up
+  # travis-ci/travis-ci#3239 to hopefully get that addressed. For now I'll
+  # manually add the pip cache directory to the build cache.
+  directories:
+    - ~/.cache/pip
+
 env:
-  - RASTERIO_VERSION=0.26.0
-addons:
-  apt:
-    packages:
-      - libgdal1h
-      - gdal-bin
+  global:
+    # These two environment variables could be set by Travis itself, or Travis
+    # could configure itself in /etc/, ~/, or inside of the virtual
+    # environments. In any case if these two values get configured then end
+    # users only need to enable the pip cache and manually run pip wheel before
+    # running pip install.
+    - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
+    - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
+
 python:
   - "2.7"
   - "3.4"
+
+addons:
+  apt:
+    packages:
+    - libgdal1h
+    - gdal-bin
+    - libgdal-dev
+    - libatlas-dev
+    - libatlas-base-dev
+    - liblapack-dev
+    - gfortran
+    - libgmp-dev
+    - libmpfr-dev
+
+
 cache:
   directories:
     - $HOME/.pip-cache/
     - $HOME/wheelhouse
+
 before_install:
-  - "./.travis_riodeps.sh"
+  - pip install -U pip
+  - pip install wheel
+
 install:
-  - "pip install -U pip"
-  - "pip install --use-wheel --find-links=$HOME/wheelhouse coveralls --cache-dir $HOME/.pip-cache"
-  - "pip install --use-wheel --find-links=$HOME/wheelhouse -e .[test] --cache-dir $HOME/.pip-cache"
+  - "pip wheel -r requirements.txt"
+  # Actually install our dependencies now, this will pull from the directory
+  # that the first command placed the Wheels into.
+  - "pip install -e .[test]"
+
 script:
   - py.test --cov riomucho --cov-report term-missing
+
 after_success:
   - coveralls

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # rio-mucho
+
 Parallel processing wrapper for rasterio
 
-[![Build Status](https://travis-ci.org/mapbox/rio-mucho.svg?branch=master)](https://travis-ci.org/mapbox/rio-mucho)[![Coverage Status](https://coveralls.io/repos/mapbox/rio-mucho/badge.svg?branch=master&service=github)](https://coveralls.io/github/mapbox/rio-mucho?branch=master)
+ [![PyPI](https://img.shields.io/pypi/v/rio-mucho.svg?maxAge=2592000?style=plastic)]() [![Build Status](https://travis-ci.org/mapbox/rio-mucho.svg?branch=master)](https://travis-ci.org/mapbox/rio-mucho) [![Coverage Status](https://coveralls.io/repos/mapbox/rio-mucho/badge.svg?branch=master&service=github)](https://coveralls.io/github/mapbox/rio-mucho?branch=master)
 
 ## Install
 
 From pypi:
 
-`pip install rio-mucho --pre`
+`pip install rio-mucho`
 
 From github (usually for a branch / dev):
 

--- a/README.rst
+++ b/README.rst
@@ -3,14 +3,14 @@ rio-mucho
 
 Parallel processing wrapper for rasterio
 
-|Build Status|
+|PyPI| |Build Status| |Coverage Status|
 
 Install
 -------
 
 From pypi:
 
-``pip install rio-mucho --pre``
+``pip install rio-mucho``
 
 From github (usually for a branch / dev):
 
@@ -32,7 +32,7 @@ Usage
     with riomucho.RioMucho([{inputs}], {output}, {run function},
         windows={windows},
         global_args={global arguments}, 
-        meta={meta to write}) as rios:
+        options={options to write}) as rios:
 
         rios.run({processes})
 
@@ -100,10 +100,10 @@ want to be accessible in the ``run_function``. ``[Default = {}]``
         'divide_value': 2
     }
 
-``meta={keyword args}``
-^^^^^^^^^^^^^^^^^^^^^^^
+``options={keyword args}``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The meta to pass to the output. ``[Default = srcs[0].meta``
+The options to pass to the writing output. ``[Default = srcs[0].meta``
 
 Example
 -------
@@ -123,9 +123,9 @@ Example
     with rasterio.open('/tmp/test_1.tif') as src:
         ## grabbing the windows as an example. Default behavior is identical.
         windows = [[window, ij] for ij, window in src.block_windows()]
-        meta = src.meta
+        options = src.meta
         # since we are only writing to 2 bands
-        meta.update(count=2)
+        options.update(count=2)
 
     global_args = {
         'divide': 2
@@ -137,7 +137,7 @@ Example
     with riomucho.RioMucho(['input1.tif','input2.tif'], 'output.tif', basic_run,
         windows=windows,
         global_args=global_args, 
-        meta=meta) as rm:
+        options=options) as rm:
 
         rm.run(processes)
 
@@ -170,5 +170,9 @@ Separate RGB files
     open_files = [rasterio.open(f) for f in files]
     rgb = `riomucho.utils.array_stack([src.read() for src in open_files])
 
+.. |PyPI| image:: https://img.shields.io/pypi/v/rio-mucho.svg?maxAge=2592000?style=plastic
+   :target: 
 .. |Build Status| image:: https://travis-ci.org/mapbox/rio-mucho.svg?branch=master
    :target: https://travis-ci.org/mapbox/rio-mucho
+.. |Coverage Status| image:: https://coveralls.io/repos/mapbox/rio-mucho/badge.svg?branch=master&service=github
+   :target: https://coveralls.io/github/mapbox/rio-mucho?branch=master

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+click
+numpy
+rasterio

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 from codecs import open as codecs_open
 from setuptools import setup, find_packages
 
@@ -6,6 +7,8 @@ from setuptools import setup, find_packages
 with codecs_open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(name='rio-mucho',
       version='0.1.1',
@@ -20,12 +23,8 @@ setup(name='rio-mucho',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=False,
-      install_requires=[
-          'click',
-          'rasterio',
-          'numpy'
-      ],
+      install_requires=read('requirements.txt').splitlines(),
       extras_require={
-          'test': ['pytest', 'pytest-cov'],
+          'test': ['pytest', 'pytest-cov', 'coveralls'],
       }
       )


### PR DESCRIPTION
This PR:
- Updates the `.travis.yml` so that it builds/caches rasterio wheels correctly (copied from supermercado)
- Adds a PyPi badge
- Adds a requirements.txt
- Updates the installation instructions

cc @dnomadb 
